### PR TITLE
Remove unnecessary passing of argument to start!

### DIFF
--- a/src/kafka_streams_the_clojure_way/core.clj
+++ b/src/kafka_streams_the_clojure_way/core.clj
@@ -178,7 +178,7 @@
   (view-messages purchase-made-topic)
 
   ;; Start the topology
-  (def kafka-streams-app (start! simple-topology))
+  (def kafka-streams-app (start!))
 
   ;; You should see 2 messages on the large-transaction-made-topic topic
   (view-messages large-transaction-made-topic)


### PR DESCRIPTION
Probably, as a leftover from refactoring, `simple-topology` was being passed to `start!`, but this is not necessary.